### PR TITLE
feat(tick): use requestAnimationFrame instead of setInterval

### DIFF
--- a/__tests__/__snapshots__/should-stop-checking-on-close.js.snap
+++ b/__tests__/__snapshots__/should-stop-checking-on-close.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OauthPopup stops checking for code when popup closes 1`] = `
+exports[`OauthPopup OauthPopup stops checking for code when popup closes 1`] = `
 <div
   onClick={[Function]}
 >
@@ -21,7 +21,7 @@ exports[`OauthPopup stops checking for code when popup closes 1`] = `
 </div>
 `;
 
-exports[`OauthPopup stops checking for code when popup closes 2`] = `
+exports[`OauthPopup OauthPopup stops checking for code when popup closes 2`] = `
 <div
   onClick={[Function]}
 >

--- a/__tests__/should-stop-checking-on-close.js
+++ b/__tests__/should-stop-checking-on-close.js
@@ -4,30 +4,42 @@ import OauthPopup from "../src/index.js";
 
 jest.useFakeTimers()
 
-test('OauthPopup stops checking for code when popup closes', () => {
-    const mockCallBack = jest.fn();
-    global.open = jest.fn().mockReturnValue({
-        location: "http://www.google.com?code=amazing"
+describe('OauthPopup', () => {
+    beforeEach(() => {
+        jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb);
     });
 
-    const component = renderer.create(
-        <OauthPopup
-            onCode={mockCallBack}
-        >
-            <div>coooooooool</div>
-            <h2>siiiiiiiick</h2>
-            <h2>leeegiiiiit</h2>
-            <button>Doooooope</button>
-        </OauthPopup>
-    );
-    let popup = component.toJSON();
-    expect(popup).toMatchSnapshot();
-    popup.props.onClick();
-    popup = component.toJSON();
-    expect(popup).toMatchSnapshot();
-    expect(global.open).toBeCalled();
-    jest.runAllTimers();
-    expect(setInterval).toHaveBeenCalledTimes(1);
-    expect(clearInterval).toHaveBeenCalledTimes(1);
-    expect(mockCallBack).toHaveBeenCalledTimes(1);
-});
+    afterEach(() => {
+        window.requestAnimationFrame.mockRestore();
+    });
+
+    test('OauthPopup stops checking for code when popup closes', () => {
+        const mockCallBack = jest.fn();
+        global.open = jest.fn().mockReturnValue({
+            location: "http://www.google.com?code=amazing"
+        });
+
+        const component = renderer.create(
+            <OauthPopup
+                onCode={mockCallBack}
+            >
+                <div>coooooooool</div>
+                <h2>siiiiiiiick</h2>
+                <h2>leeegiiiiit</h2>
+                <button>Doooooope</button>
+            </OauthPopup>
+        );
+        let popup = component.toJSON();
+        expect(popup).toMatchSnapshot();
+        popup.props.onClick();
+        popup = component.toJSON();
+        expect(popup).toMatchSnapshot();
+        expect(global.open).toBeCalled();
+        jest.runAllTimers();
+        setTimeout(() => {
+            expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
+            expect(cancelAnimationFrame).toHaveBeenCalledTimes(1);
+            expect(mockCallBack).toHaveBeenCalledTimes(1);
+        }, 1)
+    });
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -10279,7 +10279,7 @@
       }
     },
     "react-dev-utils": {
-      "version": "5.0.2",
+      "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-5.0.2.tgz",
       "integrity": "sha512-d2FbKvYe4XAQx5gjHBoWG+ADqC3fGZzjb7i9vxd/Y5xfLkBGtQyX7aOb8lBRQPYUhjngiD3d49LevjY1stUR0Q==",
       "dev": true,

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ export default class OauthPopup extends React.PureComponent<props> {
     );
     this.animationFrameId = requestAnimationFrame(this.tick);
     this.externalWindow.onbeforeunload = () => {
-      this.closeExternalWindow
+      this.closeExternalWindow()
     }
   };
 

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -3,6 +3,23 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import OauthPopup from "../src/";
 
-storiesOf("Oauth-Popups", module).add("basic", () => (
-  <OauthPopup> yo </OauthPopup>
-));
+storiesOf("Oauth-Popups", module)
+  .add("basic", () => (
+    <OauthPopup>basic</OauthPopup>
+  ))
+  .add("basic with url and callback", () => (
+    <OauthPopup
+      url="?selectedKind=Oauth-Page&selectedStory=basic%20oauth%20page&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel"
+      onCode={(code, params) => console.log(code, params)}
+      onClose={() => console.log('Popup closed')}
+    >
+      basic with url and callback
+    </OauthPopup>
+  ));
+
+storiesOf("Oauth-Page", module)
+  .add("basic oauth page", () => (
+    <a href="/?code=123&selectedKind=Oauth-Page&selectedStory=basic%20oauth%20page&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel" >
+      Connect with react-oauth-popup
+    </a>
+  ))


### PR DESCRIPTION
## Why use `requestAnimationFrame` ?
I read many articles, I think it's better to use `requestAnimationFrame` rather than `setInterval`. I made a little refactoring, I replace `setInterval` by `requestAnimationFrame` and `clearInterval` by `cancelAnimationFrame`.

Source
- https://developers.google.com/web/fundamentals/performance/rendering/optimize-javascript-execution#use_requestanimationframe_for_visual_changes